### PR TITLE
Enable building through GHC 9.10

### DIFF
--- a/versioning/versioning.cabal
+++ b/versioning/versioning.cabal
@@ -23,9 +23,9 @@ library
                      , Versioning.JSON
   other-modules:       Versioning.Internal.Equality
   build-depends:       base >=4.10 && <5
-                     , aeson >=1.0 && <2.1
-                     , bytestring >=0.10 && <0.12
-                     , semigroupoids >=5 && <6
+                     , aeson >=1.0 && <2.3
+                     , bytestring
+                     , semigroupoids >=5 && <7
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:       -Wall


### PR DESCRIPTION
Note that this removes constraints from bytestring because it is a core package distributed with GHC itself, so it should just use the version provided with the GHC distribution.